### PR TITLE
Fix missing get_last_trade attribute error

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ class Trader:
         self.ai = AIAgent()
 
     def get_price(self) -> float:
-        trade = safe_api_call(self.api.get_last_trade, self.symbol)
+        trade = safe_api_call(self.api.get_latest_trade, self.symbol)
         return float(trade.price)
 
     def submit_order(self, side: str, qty: int):


### PR DESCRIPTION
## Summary
- call `get_latest_trade` instead of removed `get_last_trade`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_688705d2893883208312a6100121aa89