### PR TITLE
Fix OpenAI API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project provides a simple algorithmic trading bot that interacts with the A
    ```bash
    pip install -r requirements.txt
    ```
+   This project requires `openai>=1.0` and uses the new `OpenAI` client
+   interface. Older code relying on `openai.ChatCompletion` will not work.
 3. Run the bot:
    ```bash
    python main.py

--- a/main.py
+++ b/main.py
@@ -40,7 +40,9 @@ class AIAgent:
     def __init__(self):
         self.use_openai = openai is not None and os.getenv('OPENAI_API_KEY')
         if self.use_openai:
-            openai.api_key = os.getenv('OPENAI_API_KEY')
+            self.client = openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+        else:
+            self.client = None
 
     def generate_trade(self, last_price: float) -> str:
         if self.use_openai:
@@ -49,12 +51,12 @@ class AIAgent:
                 "Should we 'buy', 'sell', or 'hold'?"
             )
             try:
-                response = openai.ChatCompletion.create(
+                response = self.client.chat.completions.create(
                     model="gpt-3.5-turbo",
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=1,
                 )
-                decision = response.choices[0].message["content"].strip().lower()
+                decision = response.choices[0].message.content.strip().lower()
                 if decision not in {"buy", "sell", "hold"}:
                     decision = "hold"
             except Exception as exc:


### PR DESCRIPTION
## Summary
- use `OpenAI` client for chat completions
- document the newer OpenAI Python interface

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68870b1dc1788320a56e5cff03da3442